### PR TITLE
changed PIL to Pillow in line with PyPi naming

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ wheel>=0.29
 
 # streamlit
 plotly
-PIL
+Pillow
 
 # data science
 numpy


### PR DESCRIPTION
Requirements file was erroring with 'PIL' as the module name. 

PIL is called 'Pillow' in PyPi (which is where the module is being installed from) :) 